### PR TITLE
Bug 531945: Doc line comparison fix

### DIFF
--- a/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/DocLineComparator.java
+++ b/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/DocLineComparator.java
@@ -175,10 +175,7 @@ public class DocLineComparator implements ITokenComparator {
 
 			int tlen= getTokenLength(thisIndex);
 			int olen= other.getTokenLength(otherIndex);
-			if (fCompareFilters != null && fCompareFilters.length > 0) {
-				String[] linesToCompare = extract(thisIndex, otherIndex, other, true);
-				return linesToCompare[0].equals(linesToCompare[1]);
-			} else if (tlen == olen) {
+			if (tlen == olen) {
 				String[] linesToCompare = extract(thisIndex, otherIndex, other, false);
 				return linesToCompare[0].equals(linesToCompare[1]);
 			}


### PR DESCRIPTION
Line comparison should not ignore the offset merely due to the presence
of filters.

Signed-off-by: Jeremy Almeter <Jeremy.Almeter@ibm.com>